### PR TITLE
Revert "chore(deps): update docker.io/eclipse-temurin docker tag to v23"

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM docker.io/eclipse-temurin:23-jdk@sha256:507b4bccd77c57a5414153ef5dc145c23faf470d65ad29d88fc06094ee4f8577
+FROM docker.io/eclipse-temurin:22-jdk@sha256:bafcdba57d6f0435f9834063101b64af8db6c16e5c415a9fa6ddaa9175537905
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
     && dpkg --add-architecture i386 \


### PR DESCRIPTION
Reverts MartinX3-AndroidDevelopment/SCRIPTS_BUILD#59

Breaks building of Android 14.
It still needs `libncurses5`.